### PR TITLE
perf: strip unnecessary modulo calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,6 @@ ekliptic.DoubleJacobi(
 ```go
 e := a.Mul(a, three)
 a = nil
-mod(e)
 ```
 
 In the above example, `a` is no longer needed, so we reclaim its memory as a new variable to avoid allocating an entirely new `big.Int` struct for `e`.

--- a/README.md
+++ b/README.md
@@ -180,9 +180,9 @@ Why would we want to represent points this way? Elliptic curve multiplication - 
 To demonstrate, notice how expensive a naive affine multiplication is compared to a Jacobian multiplication:
 
 ```
-BenchmarkMultiplyJacobi-4                      600 ops     1926201 ns/op    639940 B/op     7261 allocs/op
-BenchmarkMultiplyAffine-4                      606 ops     1926115 ns/op    641480 B/op     7284 allocs/op
-BenchmarkMultiplyAffineNaive-4                 481 ops     2457812 ns/op    545873 B/op     9147 allocs/op
+BenchmarkMultiplyJacobi-6                      675     1757329 ns/op    727070 B/op     5060 allocs/op
+BenchmarkMultiplyAffine-6                      679     1782691 ns/op    728819 B/op     5084 allocs/op
+BenchmarkMultiplyAffineNaive-6                 442     2480711 ns/op    545915 B/op     9147 allocs/op
 ```
 `ekliptic.MultiplyJacobi` and `ekliptic.MultiplyAffine` both use Jacobian math for multiplication operations under the hood. `ekliptic.MultiplyAffineNaive` is a naive implementation which uses affine addition and doubling instead of Jacobian math. It should be used for demonstrative purposes only.
 

--- a/addition.go
+++ b/addition.go
@@ -51,37 +51,29 @@ func AddJacobi(
 
 	// z1² and z2²
 	z1_pow2 := new(big.Int).Mul(z1, z1)
-	mod(z1_pow2)
 	z2_pow2 := new(big.Int).Mul(z2, z2)
-	mod(z2_pow2)
 
 	// u1 = x1 * z2²
 	u1 := new(big.Int).Mul(x1, z2_pow2)
-	mod(u1)
 
 	// u2 = x2 * z1²
 	u2 := new(big.Int).Mul(x2, z1_pow2)
-	mod(u2)
 
 	// z1³
 	z1_pow3 := z1_pow2.Mul(z1_pow2, z1)
 	z1_pow2 = nil
-	mod(z1_pow3)
 
 	// z2³
 	z2_pow3 := z2_pow2.Mul(z2_pow2, z2)
 	z2_pow2 = nil
-	mod(z2_pow3)
 
 	// s1 = y1 * z2³
 	s1 := z2_pow3.Mul(y1, z2_pow3)
 	z2_pow3 = nil
-	mod(s1)
 
 	// s2 = y2 * z1³
 	s2 := z1_pow3.Mul(y2, z1_pow3)
 	z1_pow3 = nil
-	mod(s2)
 
 	// h = u2 - u1
 	h := u2.Sub(u2, u1)
@@ -131,17 +123,14 @@ func AddJacobi(
 
 	// h²
 	hh := new(big.Int).Mul(h, h)
-	mod(hh)
 
 	// v = u1 * h²
 	v := u1.Mul(u1, hh)
 	u1 = nil
-	mod(v)
 
 	// h³
 	hhh := hh.Mul(hh, h)
 	hh = nil
-	mod(hhh)
 
 	// x3 = r² - h³ - 2*v
 	x3.Mul(r, r)

--- a/double.go
+++ b/double.go
@@ -20,33 +20,36 @@ func DoubleJacobi(
 ) {
 	// a = x1²
 	a := new(big.Int).Mul(x1, x1)
-	mod(a)
 
 	// b = y1²
 	b := new(big.Int).Mul(y1, y1)
-	mod(b)
 
 	// c = b²
 	c := new(big.Int).Mul(b, b)
-	mod(c)
 
-	// d = 2 * ((x1+b)² - a - c)
-	d := b.Add(b, x1)
+	// The official dbl-2009-l formula specifies:
+	//  d = 2 * ((x1+b)² - a - c)
+	//
+	// But it can be simplified, because:
+	//  a = x1², c = b²
+	//  d = 2 * ((x1+b)² - a - c)
+	//    = 2 * ((x1+b)² - x1² - b²)
+	//    = 2 * ((x1+b)(x1+b) - x1² - b²)
+	//    = 2 * (x1² + 2(x1*b) + b² - x1² - b²)
+	//    = 2 * 2(x1*b)
+	//
+	// So actually:
+	//  d = 4 * x1 * b
+	d := b.Mul(b, x1)
+	d.Mul(d, four)
 	b = nil
-	d.Mul(d, d)
-	d.Sub(d, a)
-	d.Sub(d, c)
-	d.Mul(d, two)
-	mod(d)
 
 	// e = 3 * a
 	e := a.Mul(a, three)
 	a = nil
-	mod(e)
 
 	// f = e²
 	f := new(big.Int).Mul(e, e)
-	mod(f)
 
 	// x3 = f - 2 * d
 	x3.Mul(d, two)

--- a/equal.go
+++ b/equal.go
@@ -53,9 +53,7 @@ func EqualJacobi(
 
 	// z1² and z2²
 	z1_pow2 := new(big.Int).Mul(z1, z1)
-	mod(z1_pow2)
 	z2_pow2 := new(big.Int).Mul(z2, z2)
-	mod(z2_pow2)
 
 	// u1 = x1 * z2²
 	u1 := new(big.Int).Mul(x1, z2_pow2)
@@ -73,12 +71,10 @@ func EqualJacobi(
 	// z1³
 	z1_pow3 := z1_pow2.Mul(z1_pow2, z1)
 	z1_pow2 = nil
-	mod(z1_pow3)
 
 	// z2³
 	z2_pow3 := z2_pow2.Mul(z2_pow2, z2)
 	z2_pow2 = nil
-	mod(z2_pow3)
 
 	// s1 = y1 * z2³
 	s1 := z2_pow3.Mul(y1, z2_pow3)

--- a/is_on_curve.go
+++ b/is_on_curve.go
@@ -63,7 +63,6 @@ func IsOnCurveJacobi(x, y, z *big.Int) bool {
 	// This is more efficient for larger powers than repeated .Mul() calls
 	z6b := new(big.Int).Exp(z, six, Secp256k1_P)
 	z6b.Mul(z6b, Secp256k1_B)
-	mod(z6b)
 
 	// x³ + z⁶b
 	right := new(big.Int).Mul(x, x)


### PR DESCRIPTION
I did some CPU profiling on the benchmarks, and found that the biggest single operation slowing us down was coming from `mod()` calls. This isn't too surprising - Jacobian points are used precisely to avoid excessive use of modulo operations, as they require expensive division. However, there were a lot of places where I was doing `mod` unnecessarily.

Numbers only need to be taken modulo `P` when they are either being compared with one-another directly, being returned to the caller, or being subtracted in such a way that might result in negative values being fed into forthcoming multiplicative operations. 

Other than those cases, modulo operations can be pruned.

-----

I also found a improvement in the dbl-2009-l jacobian point doubling formula, where the expression for `d` can be simplified.

I discovered that when I removed the `mod(d)` call, the formula still worked. After expanding the terms to investigate, I realized the expression for `d` is always positive, and happened to notice an opportunity to simplify, removing several subtraction and multiplication operations.

The official dbl-2009-l formula specifies:
```py
d = 2 * ((x1+b)² - a - c)
```

But it can be simplified, because:
```py
a = x1², c = b²
d = 2 * ((x1+b)² - a - c)
  = 2 * ((x1+b)² - x1² - b²)
  = 2 * ((x1+b)(x1+b) - x1² - b²)
  = 2 * (x1² + 2(x1*b) + b² - x1² - b²)
  = 2 * 2(x1*b)
```

So actually:
```py
d = 4 * x1 * b
``` 

Much easier on the eyes. 