### PR TITLE
feat: add Curve struct type to satisfy elliptic.Curve

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,37 @@ fmt.Printf("y: %.64x\n", publicKeyY)
 // y: bde70df51939b94c9c24979fa7dd04ebd9b3572da7802290438af2a681895441
 ```
 
+Ekliptic exports a struct type `Curve`, which satisfies the `elliptic.Curve` interface. You can use this in other libraries anywhere `elliptic.Curve` is accepted. For instance, to sign and verify data with `crypto/ecdsa`:
+
+```go
+d, _ := new(big.Int).SetString("18e14a7b6a307f426a94f8114701e7c8e774e7f9a47e2c2035db29a206321725", 16)
+key := &ecdsa.PrivateKey{
+  D: d,
+  PublicKey: ecdsa.PublicKey{
+    Curve: new(ekliptic.Curve),
+    X:     new(big.Int),
+    Y:     new(big.Int),
+  },
+}
+
+// Compute the public key
+ekliptic.MultiplyBasePoint(key.D, key.X, key.Y)
+
+hashedMessage := sha256.Sum256([]byte("i love you"))
+
+r, s, err := ecdsa.Sign(rand.Reader, key, hashedMessage[:])
+if err != nil {
+  panic("failed to compute signature: " + err.Error())
+}
+
+if ecdsa.Verify(&key.PublicKey, hashedMessage[:], r, s) {
+  fmt.Println("verified ECDSA signature using crypto/ecdsa")
+}
+
+// output:
+// verified ECDSA signature using crypto/ecdsa
+```
+
 ## Hacking on Ekliptic
 
 | Command | Usage |

--- a/curve.go
+++ b/curve.go
@@ -1,0 +1,77 @@
+package ekliptic
+
+import (
+	"crypto/elliptic"
+	"math/big"
+)
+
+// Curve satisfies crypto/elliptic.Curve using the secp256k1 curve paramters.
+type Curve struct {
+	params *elliptic.CurveParams
+}
+
+// Params returns the parameters for the curve. Satisfies elliptic.Curve.
+func (c *Curve) Params() *elliptic.CurveParams {
+	if c.params == nil {
+		c.params = &elliptic.CurveParams{
+			P:       new(big.Int).Set(Secp256k1_P),
+			N:       new(big.Int).Set(Secp256k1_CurveOrder),
+			B:       new(big.Int).Set(Secp256k1_B),
+			Gx:      new(big.Int).Set(Secp256k1_GeneratorX),
+			Gy:      new(big.Int).Set(Secp256k1_GeneratorY),
+			BitSize: 256,
+			Name:    "secp256k1",
+		}
+	}
+	return c.params
+}
+
+// IsOnCurve reports whether the given (x,y) lies on the curve. Satisfies elliptic.Curve.
+// Note: The elliptic.Curve interface requires that infinity is NOT on the curve.
+func (_ *Curve) IsOnCurve(x, y *big.Int) bool {
+	if equal(x, zero) && equal(y, zero) {
+		return false
+	}
+	return IsOnCurveAffine(x, y)
+}
+
+// Add returns the sum of (x1,y1) and (x2,y2) satisfies elliptic.Curve.
+func (_ *Curve) Add(x1, y1, x2, y2 *big.Int) (x3, y3 *big.Int) {
+	x3 = new(big.Int)
+	y3 = new(big.Int)
+	AddAffine(x1, y1, x2, y2, x3, y3)
+	return
+}
+
+// Double returns 2*(x,y). Satisfies elliptic.Curve.
+func (_ *Curve) Double(x1, y1 *big.Int) (x3, y3 *big.Int) {
+	x3 = new(big.Int)
+	y3 = new(big.Int)
+	DoubleAffine(x1, y1, x3, y3)
+	return
+}
+
+// ScalarMult returns k*(Bx,By) where k is a number in big-endian form.
+// Satisfies elliptic.Curve.
+func (_ *Curve) ScalarMult(x1, y1 *big.Int, k []byte) (x2, y2 *big.Int) {
+	x2 = new(big.Int)
+	y2 = new(big.Int)
+	kBig := new(big.Int).SetBytes(k)
+
+	if equal(x1, Secp256k1_GeneratorX) && equal(y1, Secp256k1_GeneratorY) {
+		MultiplyBasePoint(kBig, x2, y2)
+	} else {
+		MultiplyAffine(x1, y1, kBig, x2, y2, nil)
+	}
+	return
+}
+
+// ScalarBaseMult returns k*G, where G is the base point of the group
+// and k is an integer in big-endian form. Satisfies elliptic.Curve.
+func (_ *Curve) ScalarBaseMult(k []byte) (x2, y2 *big.Int) {
+	x2 = new(big.Int)
+	y2 = new(big.Int)
+	kBig := new(big.Int).SetBytes(k)
+	MultiplyBasePoint(kBig, x2, y2)
+	return
+}

--- a/curve_test.go
+++ b/curve_test.go
@@ -1,0 +1,98 @@
+package ekliptic
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/kklash/ekliptic/test_vectors"
+)
+
+func TestCurve(t *testing.T) {
+	curve := new(Curve)
+
+	t.Run("crypto/ecdsa", func(t *testing.T) {
+		for i, vector := range test_vectors.ECDSAVectors[:20] {
+			key := &ecdsa.PrivateKey{
+				D: vector.PrivateKey,
+				PublicKey: ecdsa.PublicKey{
+					Curve: curve,
+					X:     new(big.Int),
+					Y:     new(big.Int),
+				},
+			}
+			MultiplyBasePoint(key.D, key.X, key.Y)
+
+			hash := make([]byte, 32)
+			vector.Hash.FillBytes(hash)
+
+			r, s, err := ecdsa.Sign(rand.Reader, key, hash)
+			if err != nil {
+				t.Errorf("failed to compute signature for vector %d: %s", i, err)
+				return
+			}
+
+			if !ecdsa.Verify(&key.PublicKey, hash, r, s) {
+				t.Errorf("failed to verify ECDSA signature generated using crypto/ecdsa")
+				return
+			}
+
+			// Verify ekliptic's signatures also pass verification
+			if !ecdsa.Verify(&key.PublicKey, hash, vector.R, vector.S) {
+				t.Errorf("failed to verify ECDSA signature generated using ekliptic")
+				return
+			}
+		}
+	})
+
+	t.Run("elliptic.Marshal", func(t *testing.T) {
+		x := hexint("00cc37ea5e9e09fec6c83e5fbd7a745e3eee81d16ebd861c9e66f55518c19798")
+		y := hexint("3805231b2cba4ed1b48630790489ec4b9cd44c76455856ca7c6402e0400c5d90")
+
+		expectedPubKey, _ := hex.DecodeString(
+			"04" +
+				"00cc37ea5e9e09fec6c83e5fbd7a745e3eee81d16ebd861c9e66f55518c19798" +
+				"3805231b2cba4ed1b48630790489ec4b9cd44c76455856ca7c6402e0400c5d90",
+		)
+
+		pubKey := elliptic.Marshal(curve, x, y)
+
+		if !bytes.Equal(pubKey, expectedPubKey) {
+			t.Errorf("Unexpected uncompressed public key:\nWanted '%x'\nGot    '%x'", expectedPubKey, pubKey)
+			return
+		}
+
+		parsedX, parsedY := elliptic.Unmarshal(curve, pubKey)
+
+		if !equal(parsedX, x) || !equal(parsedY, y) {
+			t.Errorf(`unmarshaled unexpected public key coordinates:
+  x: %.64x
+  y: %.64x
+Wanted:
+  x: %.64x
+  y: %.64x
+`, parsedX, parsedY, x, y)
+			return
+		}
+	})
+
+	t.Run("IsOnCurve", func(t *testing.T) {
+		if curve.IsOnCurve(zero, zero) {
+			t.Errorf("expected infinity not to be considered on curve")
+			return
+		}
+	})
+
+	t.Run("Params", func(*testing.T) {
+		p := curve.Params().P
+		p.Sub(p, one)
+		if equal(Secp256k1_P, p) {
+			t.Errorf("expected CurveParams to be independent of ekliptic constants")
+			return
+		}
+	})
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,6 +1,8 @@
 package ekliptic_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/rand"
 	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -110,4 +112,33 @@ func ExampleWeierstrass() {
 	// uncompressed key:
 	// x: 0000000000000000000000000000000000000000000000000000000000000001
 	// y: bde70df51939b94c9c24979fa7dd04ebd9b3572da7802290438af2a681895441
+}
+
+func ExampleCurve() {
+	d, _ := new(big.Int).SetString("18e14a7b6a307f426a94f8114701e7c8e774e7f9a47e2c2035db29a206321725", 16)
+	key := &ecdsa.PrivateKey{
+		D: d,
+		PublicKey: ecdsa.PublicKey{
+			Curve: new(ekliptic.Curve),
+			X:     new(big.Int),
+			Y:     new(big.Int),
+		},
+	}
+
+	// Compute the public key
+	ekliptic.MultiplyBasePoint(key.D, key.X, key.Y)
+
+	hashedMessage := sha256.Sum256([]byte("i love you"))
+
+	r, s, err := ecdsa.Sign(rand.Reader, key, hashedMessage[:])
+	if err != nil {
+		panic("failed to compute signature: " + err.Error())
+	}
+
+	if ecdsa.Verify(&key.PublicKey, hashedMessage[:], r, s) {
+		fmt.Println("verified ECDSA signature using crypto/ecdsa")
+	}
+
+	// output:
+	// verified ECDSA signature using crypto/ecdsa
 }


### PR DESCRIPTION
Fixes #4 

Not going to remove `ekliptic.NewPrivateKey` as suggested in the issue. Callers may want an obvious way of generating keys. Also, `elliptic.GenerateKey` returns the private key as a byte slice, which is contrary to the idiom in Ekliptic (using `big.Int`s for everything).